### PR TITLE
fix(zshrc): guard anyenv init and correct KREW_ROOT path

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,14 +21,16 @@ export PATH="$HOME/.cargo/bin:$PATH"
 
 export PATH="$HOME/.bin:$PATH"
 
-# krew
-export PATH="${KWER_ROOT:-$HOME/.krew}/bin:$PATH"
+# krew: fix env var name (KREW_ROOT)
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 
 fpath=($HOME/.zsh/completion $fpath)
 
-# anyenv
-export PATH="$HOME/.anyenv/bin:$PATH"
-eval "$(anyenv init -)"
+# anyenv: guard initialization when not installed
+if command -v anyenv >/dev/null 2>&1; then
+    export PATH="$HOME/.anyenv/bin:$PATH"
+    eval "$(anyenv init -)"
+fi
 
 # Go
 export GOPATH="$HOME/go"

--- a/etc/load.sh
+++ b/etc/load.sh
@@ -1,4 +1,4 @@
-#!/usr/bash
+#!/usr/bin/env bash
 
 export PLATFORM
 


### PR DESCRIPTION
Fixes #14

Why this is a problem
- anyenv init without a guard: When `anyenv` is not installed, `.zshrc` tries to run `anyenv` on every shell start, causing errors and slowing down login shells.
- KREW_ROOT typo (`KWER_ROOT`): The wrong env var prevents adding krew’s bin directory to `PATH`, so `kubectl krew` plugins won’t resolve unless a user manually tweaks `PATH`.

What changed
- Guard anyenv: Initialize only if `anyenv` is available on the system (`command -v anyenv`). This makes login shells robust on machines without anyenv.
- Correct PATH for krew: Use `KREW_ROOT` with a fallback to `$HOME/.krew`.

Behavior and portability
- Zsh continues to work normally; users with anyenv see the same behavior, users without anyenv see no errors.
- `kubectl krew` plugins resolve as expected when installed.

How to verify
1) Open a new Zsh session on a host without anyenv: no error messages about `anyenv` appear.
2) On a host with krew installed, `echo $PATH` includes `$HOME/.krew/bin` (or `${KREW_ROOT}/bin` if set).
3) On a host with anyenv installed, `anyenv --version` works and shims are initialized as before.
