### PR TITLE
chore(nvim): ignore .config/nvim/lua/.repro cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /.go/
 /.config/*
 !/.config/nvim/
+/.config/nvim/lua/.repro/
 !/.config/efm-langserver/
 !/.config/alacritty/
 !/.config/procs/


### PR DESCRIPTION
Fixes #43

背景/問題
- `.config/nvim/lua/.repro/` 配下には luac などのビルド済みキャッシュが生成されます。これらは環境依存でレビューのノイズとなり、意図しない大容量差分の原因になります。

解決方針
- Git 追跡対象から除外して今後コミットされないようにします（`.gitignore` に `/.config/nvim/lua/.repro/` を追加）。
- 既に追跡されているファイルがある場合は `git rm --cached -r .config/nvim/lua/.repro` で索引から外す想定でしたが、今回は追跡ファイルは存在しないことを確認済みです。

受け入れ基準
- `git status` を実行しても `.repro` 配下の変更が表示されない。
- 新規クローン/CI 環境でも `.repro` 配下が追跡対象にならない。
