### PR TITLE
feat(nvim): setup nvim-treesitter via official API

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -34,7 +34,19 @@ require('lazy').setup({
   },
   {
     'nvim-treesitter/nvim-treesitter',
-    config = function() vim.fn['config#nvim_treesitter#init']() end,
+    build = ':TSUpdate',
+    config = function()
+      require('nvim-treesitter.configs').setup({
+        highlight = { enable = true },
+        indent = { enable = false },
+        ensure_installed = {
+          'lua', 'vim', 'vimdoc', 'bash', 'json', 'yaml', 'toml', 'markdown', 'regex', 'query',
+          'go', 'python', 'rust'
+        },
+        sync_install = false,
+        auto_install = false,
+      })
+    end,
     event = { 'BufNewFile', 'BufRead' }
   },
   {


### PR DESCRIPTION
Fixes #44

背景/問題
- `vim.fn['config#nvim_treesitter#init']()` に依存していましたが、該当関数が見当たらず初期化漏れの恐れがありました。

変更点
- `nvim-treesitter` の設定を公式 API で直接記述しました。
  - `require('nvim-treesitter.configs').setup({ ... })`
  - `highlight.enable = true` を有効化
  - `ensure_installed` に代表的な言語（lua, vim, bash, json, yaml, toml, markdown, regex, query, go, python, rust など）を追加
  - `build = ':TSUpdate'` でパーサ更新をサポート（lazy.nvim 経由）
  - ネットワーク事情を考慮し、`auto_install = false` / `sync_install = false`

検証方法
1) `:checkhealth nvim-treesitter` が OK であること
2) ソースコード（Lua など）で Treesitter ハイライトが有効になっていること
3) `:TSInstall lua` 等で必要パーサを追加できること

補足
- `indent` は一部言語で副作用があるため `enable=false` にしています（必要に応じて有効化可）。
