### PR TITLE
feat(nvim): migrate rainbow to Treesitter-based nvim-ts-rainbow2

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -43,9 +43,22 @@ require('lazy').setup({
   {
     'Mofiqul/vscode.nvim'
   },
+  -- Use Treesitter-based rainbow parentheses
   {
-    'luochen1990/rainbow',
-    config = function() vim.g.rainbow_active = 1 end
+    'HiPhish/nvim-ts-rainbow2',
+    dependencies = { 'nvim-treesitter/nvim-treesitter' },
+    config = function()
+      local ok, ts = pcall(require, 'nvim-treesitter.configs')
+      if ok then
+        ts.setup({
+          rainbow = {
+            enable = true,
+            query = 'rainbow-parens',
+            strategy = require('ts-rainbow').strategy.global,
+          },
+        })
+      end
+    end
   },
   {
     'zbirenbaum/copilot.lua',


### PR DESCRIPTION
Fixes #45

背景/問題
- `luochen1990/rainbow` は従来型で保守も緩やか。Treesitter ベースの実装に移行すると精度・パフォーマンスが向上します。

変更点
- 旧プラグインを削除し、`HiPhish/nvim-ts-rainbow2` を追加。
- `require('nvim-treesitter.configs').setup` に `rainbow` セクションを追加し、`rainbow-parens` クエリを使用。グローバル戦略を適用。

検証方法
1) Lua/TS/JSON 等で括弧の色分けが行われること。
2) `:TSInstall lua` 等でパーサが入っている状態で色分けが有効になること。
3) エラーが出ないこと（`checkhealth` で OK）。
