### PR TITLE
tweak(nvim): Telescope initial_mode=insert and refine ignore patterns

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -107,11 +107,12 @@ require('lazy').setup({
       require('telescope').setup {
         defaults = {
           file_ignore_patterns = {
-            '^.git/',
-            '^node_modules/'
+            '^%.git/',
+            '^node_modules/',
+            '^%.cache/',
           },
           winblend = 50,
-          initial_mode = 'normal',
+          initial_mode = 'insert',
           mappings = {
             i = {
               ["<C-j>"] = actions.move_selection_next,


### PR DESCRIPTION
Fixes #47

背景/問題
- 一般的な操作感では Telescope は insert モード開始が多く、`normal` だと検索フローに一手増えます。
- 除外パターンが `'^.git/'` のようにドットをエスケープしておらず、マッチが意図通りでない可能性があります。`.cache/` も除外対象に追加可能です。

変更点
- `initial_mode = 'insert'` に変更。
- `file_ignore_patterns` を `'^%.git/'`, `'^node_modules/'`, `'^%.cache/'` に調整。

確認方法
1) `:Telescope find_files` 実行時に insert モードで入力できること。
2) `.git/` や `.cache/`、`node_modules/` 配下が候補に出ないこと。
