### PR TITLE
feat(nvim): UI/UX improvements — lualine diagnostics/branch, gitsigns, which-key

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -30,7 +30,9 @@ require('lazy').setup({
           globalstatus = true
         },
         sections = {
-          lualine_c = { { 'filename', path = 1 } }
+          lualine_b = { 'branch', 'diff' },
+          lualine_c = { { 'filename', path = 1 } },
+          lualine_x = { { 'diagnostics', sources = { 'nvim_diagnostic' } }, 'encoding', 'fileformat', 'filetype' }
         }
       })
     end
@@ -227,6 +229,25 @@ require('lazy').setup({
     'petertriho/nvim-scrollbar',
     config = function()
       require('scrollbar').setup()
+    end
+  },
+  {
+    'lewis6991/gitsigns.nvim',
+    config = function()
+      require('gitsigns').setup()
+      -- Hunk navigation
+      vim.keymap.set('n', ']c', require('gitsigns').next_hunk, { desc = 'Next Hunk' })
+      vim.keymap.set('n', '[c', require('gitsigns').prev_hunk, { desc = 'Prev Hunk' })
+      -- Common actions
+      vim.keymap.set('n', '<leader>hs', require('gitsigns').stage_hunk, { desc = 'Stage Hunk' })
+      vim.keymap.set('n', '<leader>hr', require('gitsigns').reset_hunk, { desc = 'Reset Hunk' })
+      vim.keymap.set('n', '<leader>hp', require('gitsigns').preview_hunk, { desc = 'Preview Hunk' })
+    end
+  },
+  {
+    'folke/which-key.nvim',
+    config = function()
+      require('which-key').setup()
     end
   },
   {


### PR DESCRIPTION
Fixes #48

目的
- 日常操作の視認性・操作性を向上（ブランチ/診断の可視化、差分の行単位表示、キーマップのヒント）。

変更点
- lualine: `branch`/`diff` を `lualine_b` に、`diagnostics(nvim_diagnostic)` を `lualine_x` に追加。`encoding/fileformat/filetype` も表示。
- gitsigns: 追加・有効化。`[c`/`]c` で hunk 移動、`<leader>hs/hr/hp` で stage/reset/preview を定義。
- which-key: 追加・有効化。リーダー系マッピングの学習を補助。

備考
- diagnostics は `nvim_diagnostic` を参照します（Coc 利用中でも問題はありませんが、空の場合があります）。必要に応じて Coc 用のステータス表示を追加検討できます。

検証方法
1) ステータスラインに current branch/diff/diagnostics が表示される。
2) 変更のあるファイルでサインカラムに +/~/− が表示され、`[c`/`]c` で hunk を移動できる。
3) `<leader>` を押すと which-key のヒントが表示される。
