### PR TITLE
chore(nvim): drop vim-code-dark; keep vscode.nvim theme only

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -43,9 +43,6 @@ require('lazy').setup({
     event = { 'BufNewFile', 'BufRead' }
   },
   {
-    'tomasiser/vim-code-dark'
-  },
-  {
     'Mofiqul/vscode.nvim'
   },
   -- Use Treesitter-based rainbow parentheses


### PR DESCRIPTION
テーマ整理\n\n- 2つの VSCode 系テーマのうち、新しめでメンテ活発な `Mofiqul/vscode.nvim` を残し、`tomasiser/vim-code-dark` を削除しました。\n- colorscheme の適用は今後 `vscode.nvim` をベースにします。必要なら README に既定テーマを追記予定。