### PR TITLE
chore(nvim): narrow Copilot filetypes (disable on TelescopePrompt/markdown)

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -82,7 +82,12 @@ require('lazy').setup({
             accept = "<C-J>"
           },
         },
-        filetypes = {},
+        -- Enable Copilot for most filetypes, but disable on prompts/docs
+        filetypes = {
+          ['*'] = true,
+          TelescopePrompt = false,
+          markdown = false,
+        },
       })
     end,
     lazy = true,


### PR DESCRIPTION
Fixes #61\n\n- Copilot をほぼ全体で有効にしつつ、TelescopePrompt と markdown では無効化。\n- 入力 UI/ドキュメントでの視認性低下や誤作動を抑制します。