### PR TITLE
feat(nvim): show Coc diagnostics in lualine (fallback to nvim_diagnostic)

### DIFF
--- a/.config/nvim/lua/init.lua
+++ b/.config/nvim/lua/init.lua
@@ -32,7 +32,7 @@ require('lazy').setup({
         sections = {
           lualine_b = { 'branch', 'diff' },
           lualine_c = { { 'filename', path = 1 } },
-          lualine_x = { { 'diagnostics', sources = { 'nvim_diagnostic' } }, 'encoding', 'fileformat', 'filetype' }
+          lualine_x = { { 'diagnostics', sources = { 'coc', 'nvim_diagnostic' } }, 'encoding', 'fileformat', 'filetype' }
         }
       })
     end


### PR DESCRIPTION
Fixes #62\n\n- lualine の diagnostics sources に 'coc' を追加し、Coc 利用時でも診断数を表示します。\n- 'nvim_diagnostic' を併記し、内蔵 LSP 利用時も従来通り表示されます。