### PR TITLE
feat(nvim): add UI basic settings and document prerequisites

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -68,6 +68,7 @@ vim.opt.foldlevel = 0
 vim.opt.foldcolumn = '1'
 
 vim.opt.termguicolors = true
+vim.opt.signcolumn = 'yes'
 
 vim.opt.completeopt:remove('preview')
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@ My best dotfiles.
 
 - Install: `curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/init.sh | sh`
 
+## Prerequisites
+
+For optimal Neovim experience with telescope-github.nvim:
+
+- **GitHub CLI (gh)**: Required for GitHub integration features
+  - macOS: `brew install gh`
+  - Ubuntu/Debian: `sudo apt install gh` or `sudo snap install gh`
+  - Other: See [GitHub CLI installation guide](https://cli.github.com/)
+
 Notes
 - Do not commit absolute, machine-specific symlinks in the repo (e.g., `nvim -> /Users/...`).
 - To link Neovim config on your machine, run one of:


### PR DESCRIPTION
## Summary
- Add `signcolumn = 'yes'` to prevent layout shift when diagnostics/gitsigns appear
- Document GitHub CLI as prerequisite in README for telescope-github.nvim functionality

## Test plan
- [x] Verify signcolumn is always visible, preventing layout shifts
- [x] Check README displays gh CLI installation instructions clearly
- [x] Confirm existing Neovim functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)