### PR TITLE
feat(tmux): modernize color theme to VS Code Dark

### DIFF
--- a/.tmux/.tmux.conf
+++ b/.tmux/.tmux.conf
@@ -44,8 +44,8 @@ bind -r P resize-pane -R 100
 # マウス操作を有効にする
 setw -g mouse on
 
-# 256色端末を使用する
-set -g default-terminal "screen-256color"
+# 256色端末を使用する (現代的な設定)
+set -g default-terminal "tmux-256color"
 set-option -ga terminal-overrides ",xterm-256color:Tc"
 set-option -sa terminal-features ',xterm-256color:RGB'
 
@@ -65,23 +65,23 @@ setw -g monitor-activity on
 set -g visual-activity on
 ## ステータスバーを上部に表示する
 set -g status-position top
-## Colorscheme: Solarized
+## Colorscheme: VS Code Dark (統一テーマ)
 
 # Default statusbar colors
-set-option -g status-style bg=colour235,fg=colour136,default
+set-option -g status-style bg=#1e1e1e,fg=#d4d4d4,default
 
 # Default window title colors
-set-window-option -g window-status-style fg=colour244,bg=default,dim
+set-window-option -g window-status-style fg=#808080,bg=default,dim
 
 # Active window title colors
-set-window-option -g window-status-current-style fg=colour166,bg=default,bright
+set-window-option -g window-status-current-style fg=#4fc1ff,bg=default,bright
 
 # Pane border
-set-option -g pane-border-style fg=colour235
-set-option -g pane-active-border-style fg=colour240
+set-option -g pane-border-style fg=#3c3c3c
+set-option -g pane-active-border-style fg=#007acc
 
 # Message text
-set-option -g message-style bg=colour235,fg=colour166
+set-option -g message-style bg=#1e1e1e,fg=#4fc1ff
 
 # Pane number display
 set-option -g display-panes-active-colour colour33 #blue


### PR DESCRIPTION
## Summary
- Update default-terminal from `screen-256color` to `tmux-256color`
- Replace Solarized colors with VS Code Dark theme colors for consistency with Neovim
- Improve visual unity across terminal tools

## Test plan
- [x] Verify tmux starts with new color scheme
- [x] Check pane borders use VS Code Dark colors
- [x] Confirm status bar matches new theme

Part of #70

🤖 Generated with [Claude Code](https://claude.ai/code)