### PR TITLE
feat(tmux): enhance keybindings for modern workflow

### DIFF
--- a/.tmux/.tmux.conf
+++ b/.tmux/.tmux.conf
@@ -14,16 +14,38 @@ set -g base-index 1
 setw -g pane-base-index 1
 
 # 設定ファイルをリロードする
-bind r source-file ~/.tmux.conf \; display "Reloaded!"
+bind r source-file ~/.tmux.conf \; display "Configuration reloaded!"
+
+# より直感的なペイン切り替え (Alt + hjkl)
+bind -n M-h select-pane -L
+bind -n M-j select-pane -D
+bind -n M-k select-pane -U
+bind -n M-l select-pane -R
+
+# Alt + 矢印キーでペインサイズ変更
+bind -n M-Left resize-pane -L 5
+bind -n M-Right resize-pane -R 5
+bind -n M-Up resize-pane -U 5
+bind -n M-Down resize-pane -D 5
+
+# ウィンドウ切り替え
+bind -n M-1 select-window -t 1
+bind -n M-2 select-window -t 2
+bind -n M-3 select-window -t 3
+bind -n M-4 select-window -t 4
+bind -n M-5 select-window -t 5
 
 # C-a*2でtmux内のプログラムにC-aを送る
 bind C-a send-prefix
 
-# | でペインを縦に分割する
-bind | split-window -h
+# | でペインを縦に分割する (現在のパスを継承)
+bind | split-window -h -c '#{pane_current_path}'
 
-# - でペインを横に分割する
-bind - split-window -v
+# - でペインを横に分割する (現在のパスを継承)
+bind - split-window -v -c '#{pane_current_path}'
+
+# 新しいウィンドウも現在のパスで作成
+bind c new-window -c '#{pane_current_path}'
 
 # Vimのキーバインドでペインを移動する
 bind h select-pane -L


### PR DESCRIPTION
## Summary  
- Split panes and new windows now inherit current working directory
- Add Alt+hjkl for prefix-free pane navigation (no need for prefix key)
- Add Alt+arrow keys for quick pane resizing
- Add Alt+1-5 for fast window switching
- Improve configuration reload message

## New Keybindings
- **Alt+h/j/k/l**: Navigate panes without prefix
- **Alt+←/→/↑/↓**: Resize panes quickly
- **Alt+1-5**: Switch to windows 1-5 instantly
- **Prefix + |/-/c**: Create splits/windows in current directory

## Test plan
- [x] Test pane navigation with Alt+hjkl
- [x] Test pane resizing with Alt+arrows
- [x] Test window switching with Alt+numbers
- [x] Verify new panes/windows inherit current path

Part of #70

🤖 Generated with [Claude Code](https://claude.ai/code)