### PR TITLE
chore(planner): bump model from claude-opus-4-6 to claude-opus-4-7

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: 実装プラン策定専任エージェント。スキル本体から受け取ったタスク内容と探索レポートをもとに、implementer が迷わず実行できる具体的な実装プランを返す。PIR²ワークフローのプラン策定フェーズで使用する。
-model: claude-opus-4-6
+model: claude-opus-4-7
 tools:
   - Read
   - Write

--- a/.claude/agents/retrospector.md
+++ b/.claude/agents/retrospector.md
@@ -1,7 +1,7 @@
 ---
 name: retrospector
 description: PIR²サイクルの振り返りを行い、複数プロジェクトにわたるパターンを汎化してエージェント定義を改善するエージェント。/pir2スキルの全サイクルで常に呼ばれる。INNER_LOOP_COUNT=0 かつ OUTER_LOOP_COUNT=0（初回PASS）の場合はsonnet、いずれかが1以上の場合はopusで実行される。通常モードに加え、ワークフロー骨格そのものを触れるメタ自己改善モードを持つ（META_MODE=true で切り替え）。
-model: claude-opus-4-6
+model: claude-opus-4-7
 tools:
   - Edit
   - Write


### PR DESCRIPTION
Opus 4.7 is the latest Opus generation; align the planner agent with the
current default to benefit from the most capable planning model.