### PR TITLE
feat(cursor): Cloud Environment でグローバル skills/agents を展開

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "dotfiles",
+  "install": "sh etc/cloud-bootstrap.sh"
+}

--- a/AISETUP.md
+++ b/AISETUP.md
@@ -1,32 +1,86 @@
-# AISETUP — Claude Code on the web（クラウド）で dotfiles を自動展開する
+# AISETUP — クラウドで dotfiles を自動展開する
 
-Claude Code on the web で**新しいクラウドセッションを立ち上げるたびに、どのリポジトリでも**この dotfiles（シェル設定・`~/.claude` / `~/.codex`・git hooks 等）を自動展開するためのセットアップ手順。
+新しいクラウドセッションを立ち上げるたびに、**どのリポジトリでも**この dotfiles（`~/.cursor` / `~/.claude` / `~/.codex`・git hooks 等）を自動展開するためのセットアップ手順。
 
-> ℹ️ ローカルマシン（macOS / Linux / Codespaces）の初回セットアップは [README](README.md) の「クイックスタート」を参照。本書は **Claude Code on the web（クラウド）専用**。
+> ℹ️ ローカルマシン（macOS / Linux / Codespaces）の初回セットアップは [README](README.md) の「クイックスタート」を参照。本書は **クラウド専用**。
+
+対象:
+
+| ランタイム | 器 | 登録場所 |
+|-----------|-----|---------|
+| **Cursor Cloud Agents** | Environment の `install` | [Dashboard → Environments](https://cursor.com/dashboard/cloud-agents#environments) またはリポの `.cursor/environment.json` |
+| **Claude Code on the web** | 環境の setup script | Claude Code の環境設定 |
+
+どちらも中身は同じ `etc/cloud-bootstrap.sh` → `etc/link.sh`。
 
 ---
 
-## 🎯 仕組み（なぜ setup script なのか）
+## 🎯 仕組み（なぜ Environment / setup script なのか）
 
-クラウドセッションはリポジトリを毎回クリーンに clone した使い捨てコンテナで動く。リポ内の SessionStart hook では**そのリポにしか効かない**（他リポには dotfiles が clone されない）ため、「全リポで自動展開」は実現できない。
+クラウドセッションはリポジトリを毎回クリーンに clone した使い捨て VM で動く。ノート PC の `~/.cursor/skills` は同期されない。リポ内の SessionStart hook では**そのリポにしか効かない**（他リポには dotfiles が clone されない）ため、「全リポで自動展開」は実現できない。
 
-そこで **環境の setup script**（Claude Code on the web の環境設定に登録するスクリプト）を器にする。setup script がセッション起動時に `etc/cloud-bootstrap.sh` を実行し、dotfiles を `etc/link.sh` で `$HOME` に展開する。
+そこで **クラウド Environment の install / setup script** を器にする。起動時に `etc/cloud-bootstrap.sh` が走り、`etc/link.sh` で `$HOME` に展開する（Cursor skills は symlink 非対応のため実ディレクトリへ materialize）。
 
-docs: https://code.claude.com/docs/en/claude-code-on-the-web
+- Cursor docs: https://cursor.com/docs/cloud-agent/setup
+- Claude Code docs: https://code.claude.com/docs/en/claude-code-on-the-web
 
 ---
 
-## ⏭️ 有効化の2ステップ
+## Cursor Cloud Agents
 
-登録するまでは動かない。順に行う。
+### このリポジトリ（dotfiles）上
 
-### 1. このリポジトリを利用可能にする
+`.cursor/environment.json` に次が入っている。Cloud Agent がこのリポで起動すると install が走る。
 
-`cloud-bootstrap.sh` は `master` から取得・展開する。機能を含むブランチを **`master` にマージ**しておく（マージ前は下記 URL が 404 になり、clone 側にも修正が乗らない）。
+```json
+{
+  "name": "dotfiles",
+  "install": "sh etc/cloud-bootstrap.sh"
+}
+```
 
-### 2. 環境の setup script に1行登録する
+dotfiles セッションでは in-place checkout から展開する（master を別 clone して被せない）。
 
-Claude Code on the web の環境設定 → setup script に次の1行を貼る。dotfiles は public リポなので認証不要。
+### 他リポジトリで使う（Personal Environment）
+
+ローカル home は載らない。**Dashboard の Personal Environment** に install を登録し、使いたいリポをその Environment に紐づける。
+
+1. [Cloud Agents → Environments](https://cursor.com/dashboard/cloud-agents#environments) で Personal Environment を作成（または既存を編集）
+2. **Install / update script** に次の1行を設定（public リポなので認証不要）:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-bootstrap.sh | sh
+```
+
+3. 対象リポジトリをその Environment に紐づける
+
+解決順（公式）: リポの `.cursor/environment.json` → Personal saved environment → Team saved environment。  
+他リポに `.cursor/environment.json` が無いとき、紐づけた Personal Environment の install が効く。
+
+> ⚠️ `cloud-bootstrap.sh` は **master** から取得・展開する。機能を含むブランチは **master にマージ**しておく。
+
+### Cursor での確認
+
+| 確認点 | コマンド / 期待値 |
+|--------|-------------------|
+| install が走ったか | Environment build / agent setup ログに `[cloud-bootstrap] done` |
+| skills が user scope に載ったか | `ls ~/.cursor/skills` に `cursor-*` が並ぶ（実ディレクトリ） |
+| agents が載ったか | `readlink ~/.cursor/agents` が dotfiles checkout を指す |
+| 他リポで冗長 clone | 他リポセッションでは `~/dotfiles` ができ、そこから展開 |
+
+---
+
+## Claude Code on the web
+
+### 有効化の2ステップ
+
+#### 1. このリポジトリを利用可能にする
+
+`cloud-bootstrap.sh` は `master` から取得・展開する。機能を含むブランチを **`master` にマージ**しておく。
+
+#### 2. 環境の setup script に1行登録する
+
+Claude Code on the web の環境設定 → setup script に次の1行を貼る。
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-bootstrap.sh | sh
@@ -42,7 +96,7 @@ curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-b
 
 | 状況 | 展開元 | 挙動 |
 |------|--------|------|
-| セッションが **dotfiles リポ上** | その場の checkout（`CLAUDE_PROJECT_DIR` / `PWD` / `/home/user/dotfiles` を origin が `coil398/dotfiles` かで判定） | **再 clone しない**。編集中の作業ツリーからそのまま展開する |
+| セッションが **dotfiles リポ上** | その場の checkout（`CLAUDE_PROJECT_DIR` / `CURSOR_PROJECT_DIR` / `PWD` / `/workspace` / `/home/user/dotfiles` を origin が `coil398/dotfiles` かで判定） | **再 clone しない**。編集中の作業ツリーからそのまま展開する |
 | セッションが **他リポ上** | `~/dotfiles`（無ければ clone、あれば `pull --ff-only`） | master の管理コピーから展開する |
 
 > ⚠️ dotfiles 自身を触るセッションで master を別 clone して被せると、env が編集中ブランチでなく master を反映してしまう。それを避けるため in-place を優先する。
@@ -51,7 +105,7 @@ curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-b
 
 ## ⚙️ オプション（環境変数）
 
-setup script 側で `VAR=1 curl … | VAR=1 sh` のように渡す（または `cloud-bootstrap.sh` を直接呼ぶ環境変数として）。
+setup / install 側で `VAR=1 curl … \| VAR=1 sh` のように渡す（または `cloud-bootstrap.sh` を直接呼ぶ環境変数として）。
 
 | 変数 | 既定 | 用途 |
 |------|------|------|
@@ -70,20 +124,25 @@ curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-b
 
 ## 📋 展開されるもの／スキップされるもの
 
-`etc/link.sh` が `$HOME` に symlink を張る（シェル設定・`~/.claude` 個別ファイル・`~/.codex`・`~/.githooks` + `core.hooksPath`・OpenCode/Codex/Cursor 生成物など）。
+`etc/link.sh` が `$HOME` に symlink / materialize する（シェル設定・`~/.claude` 個別ファイル・`~/.codex`・`~/.cursor`・`~/.githooks` + `core.hooksPath`・OpenCode/Codex/Cursor 生成物など）。
 
-> ⚠️ クラウドのコンテナは `~/.config`（uv / fish 等）と `~/.claude/skills`（Claude 組込みスキル）を**実ディレクトリ**として持つ。`link_dir` はこれらを検出すると symlink を張らず warn してスキップする（`~/.config/.config` のようなネスト symlink 生成やコンテナ状態の破壊を避けるため）。そのため dotfiles の `.config`（nvim/alacritty）と `.claude/skills` はクラウドでは user scope に展開されない。dotfiles リポのセッションでは、これらのスキルは project scope で自動的に利用可能。
+Cursor 向けの要点:
+
+- `~/.cursor/agents` → symlink
+- `~/.cursor/skills/<name>` → **実ディレクトリに materialize**（Cursor は symlink スキルを発見しないため）
+
+> ⚠️ クラウドのコンテナは `~/.config`（uv / fish 等）と `~/.claude/skills`（Claude 組込みスキル）を**実ディレクトリ**として持つことがある。`link_dir` はこれらを検出すると symlink を張らず warn してスキップする。そのため dotfiles の `.config`（nvim/alacritty）と `.claude/skills` はクラウドでは user scope に展開されない場合がある。dotfiles リポのセッションでは、これらのスキルは project scope で自動的に利用可能。
 
 ---
 
-## ✅ 動作確認・トラブルシュート
+## ✅ 動作確認・トラブルシュート（共通）
 
 | 確認点 | コマンド / 期待値 |
 |--------|-------------------|
 | 展開元が正しいか | `cloud-bootstrap` の出力末尾 `done (source: …)` を見る。dotfiles セッションなら in-place パス |
 | symlink が張れたか | `readlink ~/.zshrc` が dotfiles checkout を指す |
 | 冗長 clone を作っていないか | dotfiles セッションで `~/dotfiles`（`/root/dotfiles`）が**作られない** |
-| `HOME` の一致 | setup script がセッションと同じユーザー / `HOME` で走るか（ずれると静かに無反応になる）。初回展開後 `readlink ~/.zshrc` で確認 |
+| `HOME` の一致 | setup / install がセッションと同じユーザー / `HOME` で走るか（ずれると静かに無反応になる） |
 | 外側 `curl \| sh` の到達性 | 初回だけ確認。既存 `init.sh` も同じ raw URL 経由で配布実績あり |
 
 ---
@@ -91,6 +150,7 @@ curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-b
 ## 🔗 関連
 
 - `etc/cloud-bootstrap.sh` — 本手順が呼ぶブートストラップ本体
-- `etc/link.sh` — 実際の symlink 展開。リポが `~/dotfiles` 以外にあっても自身の物理位置からリポルートを導出する
+- `etc/link.sh` — 実際の symlink / Cursor skills materialize。リポが `~/dotfiles` 以外にあっても自身の物理位置からリポルートを導出する
+- `.cursor/environment.json` — このリポ向け Cursor Cloud install 設定
 - [CLAUDE.md](CLAUDE.md) — リポ内で作業する Claude 向けガイダンス
 - [README.md](README.md) — リポジトリ全体の概要とローカルセットアップ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ sh etc/link.sh
 bash install.sh
 ```
 
-### Claude Code on the web (クラウド) での自動展開
+### クラウド（Cursor Cloud / Claude Code on the web）での自動展開
 
-クラウドセッション（どのリポジトリで起動しても）で dotfiles を自動展開する手順・仕組み・オプション・トラブルシュートは **`AISETUP.md`（SSOT）** に集約。要点のみ: 環境の setup script に `curl -fsSL …/etc/cloud-bootstrap.sh | sh` を登録する方式（リポ内 SessionStart hook では他リポに dotfiles が clone されず実現できないため）。`cloud-bootstrap.sh` はセッションが dotfiles リポ上ならその場の checkout から、他リポなら `~/dotfiles` に clone してから `etc/link.sh` を実行する。手順を更新するときは `AISETUP.md` を直し、本節は追記しない。
+クラウドセッション（どのリポジトリで起動しても）で dotfiles を自動展開する手順・仕組み・オプション・トラブルシュートは **`AISETUP.md`（SSOT）** に集約。要点のみ: Cursor は Environment の `install`、Claude Code は環境の setup script に `curl -fsSL …/etc/cloud-bootstrap.sh | sh` を登録する方式（リポ内 SessionStart hook では他リポに dotfiles が clone されず実現できないため）。このリポの Cursor 向けは `.cursor/environment.json` も commit する。手順を更新するときは `AISETUP.md` を直し、本節は追記しない。
 
 ## リポジトリ構造と役割
 
@@ -54,7 +54,7 @@ dotfiles/
 - `install.sh` — **Codespaces 専用**。apt パッケージ（zsh, tmux, ripgrep, fd, bat, colordiff, tig, fzf 等）、prebuilt バイナリ（nvim, eza, procs, **gitleaks** — amd64/arm64 対応）、zplug のインストール。`etc/link.sh` の実行、zsh のデフォルトシェル設定、Neovim プラグインのヘッドレスインストール。冪等設計（`has()` チェックで既インストール時はスキップ）
 - `etc/link.sh` — `$HOME/dotfiles/.??*` を `$HOME/` にシンボリックリンク展開（`.git`, `.gitignore`, `.DS_Store`, `.claude`, `.mcp.json` は除外）。`.tmux/.tmux.conf` → `$HOME/.tmux.conf`。`.claude/` は `settings.json`, `.mcp.json`, `CLAUDE.md`, `format.md`, `pir-handoff.md`, `user-feedback-protocol.md`, `agent-delegation.md`, `pir2-protocol.md`, `dev-server.md`, `subagent-permissions.md`, `agents/`, `skills/`, `lib/` を個別に `$HOME/.claude/` へリンク。さらに `git config --global core.hooksPath ~/.githooks` を冪等に設定し、グローバル pre-commit dispatcher を有効化する。リポが `~/dotfiles` 以外に checkout されている環境（クラウドでは `/home/user/dotfiles`・`HOME=/root`）でも動くよう、`~/dotfiles` が無ければスクリプト自身の物理位置からリポルートを導出する。また `link_dir` は展開先が**実ディレクトリ**（symlink でない）の場合はネスト symlink 生成を避けて warn スキップする（クラウドが持つ実 `~/.config`（uv/fish）・`~/.claude/skills`（組込みスキル）を潰さないため）
 - `etc/init.sh` — 新規マシン向け。dotfiles を git clone → `etc/install/homebrew/install.sh` → `etc/set.sh` → `etc/link.sh` を実行
-- `etc/cloud-bootstrap.sh` — **Claude Code on the web (クラウド) 専用**の軽量ブートストラップ。環境の setup script から `curl … | sh` で呼ぶ想定。**セッションが dotfiles リポ上ならその場の checkout から展開**（`CLAUDE_PROJECT_DIR`/`PWD`/`/home/user/dotfiles` を origin が coil398/dotfiles かで判定）、それ以外のリポのときだけ `~/dotfiles`（`DOTFILES_DIR` で変更可）に clone/update してから `etc/link.sh` を実行する。dotfiles 自身を触るセッションで master を別 clone して上書きする無駄を避けるため。`DOTFILES_INSTALL=1` で `install.sh` も追加実行。link.sh は自身の物理位置からリポルートを導出するため checkout 先パスは任意でよい
+- `etc/cloud-bootstrap.sh` — **クラウド専用**（Cursor Cloud Agents / Claude Code on the web）の軽量ブートストラップ。Environment install / setup script から `curl … | sh` で呼ぶ想定（このリポの Cursor 向けは `.cursor/environment.json` からも呼ぶ）。**セッションが dotfiles リポ上ならその場の checkout から展開**（`CLAUDE_PROJECT_DIR`/`CURSOR_PROJECT_DIR`/`PWD`/`/workspace` 等を origin が coil398/dotfiles かで判定）、それ以外のリポのときだけ `~/dotfiles`（`DOTFILES_DIR` で変更可）に clone/update してから `etc/link.sh` を実行する。dotfiles 自身を触るセッションで master を別 clone して上書きする無駄を避けるため。`DOTFILES_INSTALL=1` で `install.sh` も追加実行。link.sh は自身の物理位置からリポルートを導出するため checkout 先パスは任意でよい。手順の SSOT は `AISETUP.md`
 - `etc/set.sh` — OS 判定（Darwin/Linux）。Linux: GNOME Terminal Solarized 配色、apt install、`~/.config` バックアップ＆symlink 化
 - `etc/load.sh` — シェル共通ユーティリティ関数ライブラリ（約450行）。OS 判定（`is_osx`, `is_linux`, `is_bsd`）、テキスト操作（`lower`, `upper`, `contains`）、PATH 操作（`path_remove`）、出力ヘルパー（`e_error`, `e_warning`, `e_done`, `ink`, `logging`）、条件判定（`is_login_shell`, `is_git_repo`, `is_ssh_running`）
 - `etc/install/homebrew/` — Homebrew インストール（macOS / LinuxBrew）と `brew_install.sh` によるパッケージ一括インストール（gitleaks 含む）

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ dotfiles/
 |-----------|------|
 | `install.sh` | **Codespaces 専用**。apt パッケージ・prebuilt バイナリ・zplug のインストール、symlink 展開、zsh デフォルト化、Neovim プラグインインストール |
 | `etc/init.sh` | 新規マシン向け。dotfiles を clone → `set.sh` → `link.sh` を実行 |
-| `etc/cloud-bootstrap.sh` | **Claude Code on the web（クラウド）専用**。環境の setup script から呼ぶ。dotfiles リポ上ならその場の checkout、他リポなら `~/dotfiles` に clone して `link.sh` を実行。詳細は [AISETUP.md](AISETUP.md) |
+| `etc/cloud-bootstrap.sh` | **クラウド専用**（Cursor Cloud Agents / Claude Code on the web）。Environment install / setup script から呼ぶ。dotfiles リポ上ならその場の checkout、他リポなら `~/dotfiles` に clone して `link.sh` を実行。詳細は [AISETUP.md](AISETUP.md) |
 | `etc/link.sh` | `$HOME/dotfiles/.??*` を `$HOME/` に symlink。`.claude/` / `.codex/` は個別にリンク。`.mcp.json` は除外 |
 | `etc/set.sh` | OS 判定、GNOME Terminal カラー設定、ディレクトリ構成の整理 |
 | `etc/load.sh` | OS 判定 (`is_osx`, `is_linux`)、テキスト操作、出力ヘルパー等のシェル関数 |
@@ -139,14 +139,16 @@ prebuilt イメージ `ghcr.io/coil398/dotfiles:latest` が利用可能。
 
 イメージは master push 時と毎週月曜に自動ビルド（linux/amd64 + linux/arm64）。
 
-## Claude Code on the web（クラウド）
+## クラウドでの自動展開（Cursor / Claude Code）
 
-新しいクラウドセッションを立ち上げるたびに、どのリポジトリでも dotfiles を自動展開できる。環境の setup script に `etc/cloud-bootstrap.sh` を登録する方式。手順・仕組み・オプション・トラブルシュートは **[AISETUP.md](AISETUP.md)** を参照。
+新しいクラウドセッションを立ち上げるたびに、どのリポジトリでも dotfiles（`~/.cursor` skills/agents 含む）を自動展開できる。`etc/cloud-bootstrap.sh` を Environment の install / setup script に登録する方式。手順は **[AISETUP.md](AISETUP.md)** を参照。
 
 ```sh
-# 環境の setup script に登録する1行
+# Cursor: Personal Environment の install / Claude Code: setup script に登録する1行
 curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-bootstrap.sh | sh
 ```
+
+このリポ自身の Cursor Cloud 向けには `.cursor/environment.json`（`install: sh etc/cloud-bootstrap.sh`）を commit 済み。
 
 ## Claude Code 統合
 

--- a/etc/cloud-bootstrap.sh
+++ b/etc/cloud-bootstrap.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
-# Bootstrap these dotfiles in a Claude Code on the web (cloud) session.
+# Bootstrap these dotfiles in a cloud agent / cloud IDE session.
 #
 # Cross-repo auto-deploy: a repo-committed SessionStart hook can only deploy when
 # a session is opened on THIS repo (other repos never clone dotfiles). To get the
 # dotfiles into EVERY cloud session regardless of which repo it runs on, wire this
-# script into the environment's *setup script* (Claude Code on the web ->
-# environment settings). See docs:
-#   https://code.claude.com/docs/en/claude-code-on-the-web
+# script into the cloud environment's install / setup script:
+#   - Cursor Cloud Agents: Environment install (Dashboard or .cursor/environment.json)
+#     docs: https://cursor.com/docs/cloud-agent/setup
+#   - Claude Code on the web: environment setup script
+#     docs: https://code.claude.com/docs/en/claude-code-on-the-web
+# See AISETUP.md for both.
 #
-# Recommended setup-script line (dotfiles is a public repo, so no auth needed):
+# Recommended install / setup-script line (dotfiles is a public repo, so no auth
+# needed). Use this form on *other* repos' Cursor Environments:
 #   curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-bootstrap.sh | sh
 #
-# It deploys via etc/link.sh, which symlinks the config into $HOME. link.sh
-# derives its source tree from its own location, so the checkout need not live at
-# ~/dotfiles literally.
+# On this repo, .cursor/environment.json calls:
+#   sh etc/cloud-bootstrap.sh
+#
+# It deploys via etc/link.sh, which symlinks the config into $HOME (and
+# materializes ~/.cursor/skills as real directories). link.sh derives its source
+# tree from its own location, so the checkout need not live at ~/dotfiles
+# literally.
 #
 # Source selection:
 #   - If this session is opened ON the dotfiles repo, deploy FROM that in-place
@@ -45,8 +53,9 @@ is_dotfiles_checkout() {
 
 # 1. Prefer an in-place checkout (a session opened on the dotfiles repo): deploy
 #    from the working tree the user is actually editing, without touching it.
+#    Candidates cover Claude Code on the web and Cursor Cloud (/workspace).
 if [ -z "$DOT_DIRECTORY" ]; then
-    for cand in "${CLAUDE_PROJECT_DIR:-}" "$PWD" /home/user/dotfiles; do
+    for cand in "${CLAUDE_PROJECT_DIR:-}" "${CURSOR_PROJECT_DIR:-}" "$PWD" /workspace /home/user/dotfiles; do
         if is_dotfiles_checkout "$cand"; then
             DOT_DIRECTORY="$cand"
             echo "[cloud-bootstrap] deploying from in-place checkout: $DOT_DIRECTORY"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud Agents で、他リポジトリでも dotfiles のグローバル skills / agents を使えるようにする。

- `.cursor/environment.json` を追加（このリポ上では `sh etc/cloud-bootstrap.sh` を install 実行）
- `etc/cloud-bootstrap.sh` を Cursor Cloud 対応に更新（`/workspace` 等の in-place 検出、コメント）
- `AISETUP.md` を Cursor Cloud / Claude Code 両対応の SSOT に拡張（他リポ向け Personal Environment の install 1行を記載）

## 他リポでの使い方

Dashboard の Personal Environment の install に:

```sh
curl -fsSL https://raw.githubusercontent.com/coil398/dotfiles/master/etc/cloud-bootstrap.sh | sh
```

を設定し、対象リポをその Environment に紐づける（詳細は `AISETUP.md`）。

## 検証済み

- この VM で `sh etc/cloud-bootstrap.sh` → `~/.cursor/skills/cursor-*` が 25 件 materialize
- Personal Environment draft を作成し、draft build `bld-20260801-150d86f1-b532-49be-b158-92cc6b019677` が **SUCCEEDED**
- draft は自動では active にならないため、[Environments](https://cursor.com/dashboard/cloud-agents#environments) で確認・他リポ紐づけが必要

## Test plan

- [x] この VM で bootstrap → `~/.cursor/skills` materialize 確認
- [x] Environment draft build SUCCEEDED
- [ ] master マージ後、他リポ Cloud Agent で Personal Environment 紐づけ → `ls ~/.cursor/skills` を確認

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb8fd-e719-7ccf-aa9f-a0e99b57d2a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb8fd-e719-7ccf-aa9f-a0e99b57d2a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

